### PR TITLE
declarative: skip deck operations in delete mode

### DIFF
--- a/internal/declarative/planner/deck_requirements.go
+++ b/internal/declarative/planner/deck_requirements.go
@@ -23,6 +23,13 @@ func (p *Planner) planDeckDependencies(ctx context.Context, rs *resources.Resour
 		return nil
 	}
 
+	// In delete mode, skip deck dependency planning entirely.
+	// Deleting the control plane cascades removal of all core entities
+	// that deck would otherwise manage, so running deck diff is unnecessary.
+	if opts.Mode == PlanModeDelete {
+		return nil
+	}
+
 	deckChangeIDs := make(map[string]string)
 	serviceToDeckChange := make(map[string]string)
 	neededGatewayServices := referencedGatewayServiceRefs(plan.Changes)
@@ -346,7 +353,9 @@ func (p *Planner) deckDiffHasChanges(
 	case PlanModeApply, PlanModeSync:
 		// valid modes for deck operations
 	case PlanModeDelete:
-		return false, fmt.Errorf("control_plane %s: deck diff does not support delete mode", controlPlaneRef)
+		// Delete mode skips deck operations; the control plane deletion
+		// cascades removal of all core entities deck would manage.
+		return false, nil
 	default:
 		return false, fmt.Errorf("control_plane %s: deck diff requires apply or sync mode", controlPlaneRef)
 	}


### PR DESCRIPTION
When PlanModeDelete is active, deck dependency planning is unnecessary because deleting the control plane cascades removal of all core entities (services, routes, plugins) that deck would otherwise manage.

Changes:
- planDeckDependencies() returns early in delete mode
- deckDiffHasChanges() returns false (skip) instead of an error for PlanModeDelete, making it defensively correct if called directly

All resource planners already properly skip _external resources in delete mode (control_plane, portal, organization_team planners each check IsExternal() before planning deletes).

https://claude.ai/code/session_01Xy7AWFR6QTFbZST2mKb9LA

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
